### PR TITLE
Add resizeBuffer

### DIFF
--- a/GPipe-Core/src/Graphics/GPipe/Buffer.hs
+++ b/GPipe-Core/src/Graphics/GPipe/Buffer.hs
@@ -40,6 +40,7 @@ module Graphics.GPipe.Buffer (
     bufferLength,
     writeBuffer,
     copyBuffer,
+    resizeBuffer,
     BufferStartPos,
 
     -- * Buffer colors
@@ -54,4 +55,4 @@ import           Graphics.GPipe.Internal.Buffer (B, B2, B3, B4, BPacked,
                                                  BufferStartPos,
                                                  Normalized (..), ToBuffer,
                                                  copyBuffer, newBuffer,
-                                                 writeBuffer)
+                                                 resizeBuffer, writeBuffer)

--- a/GPipe-GLFW4/test/Graphics/GPipe/BufferSpec.hs
+++ b/GPipe-GLFW4/test/Graphics/GPipe/BufferSpec.hs
@@ -20,3 +20,20 @@ spec = do
         writeBuffer buf 0 [0..50000]
         return $ bufferLength buf
       l `shouldBe` 100000
+
+  describe "resizeBuffer" $ do
+    it "from 0 to 100k, should return the new size of the buffer" $ do
+      l <- runContextT GLFW.defaultHandleConfig $ do
+        buf :: Buffer os (B Float) <- newBuffer 0
+        resized <- resizeBuffer buf 100000
+        writeBuffer resized 0 [1..100000]
+        return $ bufferLength resized
+      l `shouldBe` 100000
+
+    it "from 10 to 1, shouldn't crash on OOB write" $ do
+      l <- runContextT GLFW.defaultHandleConfig $ do
+        buf :: Buffer os (B Float) <- newBuffer 10
+        resized <- resizeBuffer buf 1
+        writeBuffer resized 0 [0..1]
+        return $ bufferLength resized
+      l `shouldBe` 1


### PR DESCRIPTION
For scenarios where input can change over time,
this adds `resizeBuffer` function to produce a new buffer
with specified length.

This causes transparent reallocation of OpenGL buffer,
producing new empty buffer of right size.